### PR TITLE
Deps/update ua parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var UserAgentParser = require('user-agent-parser');
+var UserAgentParser = require('ua-parser-js');
 var languageMessages = require('./languages.json');
 
 module.exports = function (options) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"version": "1.0.0",
 	"main": "index.js",
 	"dependencies": {
-		"user-agent-parser": "^0.6.0"
+		"ua-parser-js": "^0.7.0"
 	},
 	"author": "Mike MacCana <mike.maccana@gmail.com>",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "outdated-browser-rework",
 	"description": "Detects outdated browsers and asks users to upgrade to a new version. Handles mobile devices!",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"main": "index.js",
 	"dependencies": {
 		"ua-parser-js": "^0.7.0"


### PR DESCRIPTION
Quick update of the `user-agent-parser` dependency.

The npm entry's name has been updated to `ua-parser-js` (it's the same repository though - see last line of `npm info` screenshot)

This fixes issue #5 (and possibly #1 as well - looks like the same problem)

![screen shot 2016-01-06 at 11 31 26 am](https://cloud.githubusercontent.com/assets/489896/12152389/3d9359da-b469-11e5-82b7-4e36b7fd4f76.png)
