### PR TITLE
add option unknownBrowserOk,  support can not list many browser agent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ If you like, specify options, eg:
             'IE': false
         },
         requireChromeOnAndroid: true,
+        unknownBrowserOk: true,  // default is false, unknown browser always be out date.set true let unknown browser self is not out date (but can detect by requiredCssProperty later).
         // Specify messaages if you want to custommize them
         // See languages.json for more details
         messages: {

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ module.exports = function (options) {
       var isOutOfDate = false;    
       if ( ! browserSupport[browserName] ) {
       	// support for unknown browser can be config to not out date,
-				if(!!options.unknownBrowserOk) isOutOfDate = true;
+				if(!options.unknownBrowserOk) isOutOfDate = true;
       } else if (browserMajorVersion < browserSupport[browserName]) {
         isOutOfDate = true;
       }

--- a/index.js
+++ b/index.js
@@ -84,7 +84,8 @@ module.exports = function (options) {
       }
       var isOutOfDate = false;    
       if ( ! browserSupport[browserName] ) {
-        isOutOfDate = true
+      	// support for unknown browser can be config to not out date,
+				if(!!options.unknownBrowserOk) isOutOfDate = true;
       } else if (browserMajorVersion < browserSupport[browserName]) {
         isOutOfDate = true;
       }


### PR DESCRIPTION
there were many custom android OS, and cannot list these browser agents, so, add option unknownBrowserOk, the default is false, the unknown browser always is out date.
set true let unknown browser self is not out of date (but can detect by requiredCssProperty later).