### PR TITLE
Update README to mention the importance of doctype declaration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ Add the required HTML at the end of your document:
 
 Yes, [IDs suck](http://2ality.com/2012/08/ids-are-global.html) but old browsers don't support gettting elements by class name.
 
+You should also always use HTML <!DOCTYPE> declaration to tell legacy browsers that you're using full standards mode. Without this it's possible that your page gets loaded in the quirks mode and it will not work with this package.   
+For more information, see: https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode
+
 ## Bundling the JavaScript
 
 In modern times we normally concatenate and combine different JS modules using [browserify](http://browserify.org/) or [webpack](https://webpack.js.org/): **it's best to bundle outdated-browser-rework by itself**. Since other scripts may expect things like `console` and `function.bind()` to exist, they won't work on old browsers - if you bundle this with other software, the JS will probably fail before outdated-browser has a chance to do any work.


### PR DESCRIPTION
As discussed in this issue: https://github.com/mikemaccana/outdated-browser-rework/issues/102
Without doctype declaration legacy browsers might be by default in the quirks mode which breaks the banner.